### PR TITLE
Add default path for file creation

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -61,13 +61,13 @@ const fileReader = async () => {
       // creat a file:
       // creat a file <path>
       const creatFile = async () => {
-        const cmdMatch = /^create a file ([\S]+) of name ([\S]+)$/i; // Regex to match "create a file <path>"
+        const cmdMatch = /^create a file(?: ([\S]+))? of name ([\S]+)$/i; // Regex to match "create a file <path>"
 
         let cmdVerification = command.match(cmdMatch); // this will return an object
 
         if (cmdVerification) {
           console.log(`Command verification sucessful`);
-          let dirPath = cmdVerification[1].trim();
+          let dirPath = cmdVerification[1] ? cmdVerification[1].trim() : __dirname;
           let fileName = cmdVerification[2].trim();
           const FilePath = path.join(dirPath, fileName);
           try {


### PR DESCRIPTION
Update `cmdMatch` regex and `creatFile` function to handle default path for file creation.

* Update `cmdMatch` regex to allow for an optional path.
* Add a default value for the path if it is not provided, defaulting to the current directory (`__dirname`).
* Update `creatFile` function to handle the default path.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/thDemon1310/text-command-to-fs-operation-in-Node/pull/1?shareId=ccbf883b-f48e-406b-843e-a8e7e05efa6a).